### PR TITLE
Fix architecture condition in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,7 +22,7 @@ else
     exit 1
 fi
 
-if [["$architecture" == "x86_64"]]; then
+if [[ "$architecture" == "x86_64" ]]; then
   architecture="amd64"
 fi
 


### PR DESCRIPTION
Fixed install.sh script to avoid the error "./install.sh: line 25: [[x86_64: command not found".