### PR TITLE
Enhance file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,22 @@ The default temporary download folder path will be the title of the book. Howeve
 anyflip-downloader -temp-download-folder <temp folder name> <url to book>
 ```
 
+### Advanced file download options
+
+#### Parallel retrieval
+By default, downloads are performed in a single thread. To improve performance, multiple pages can be downloaded simultaneously. Use the `-threads` flag to control the number of parallel jobs.
+```sh
+anyflip-downloader -threads <number of parallel jobs> <url to book>
+```
+
+#### Download retries
+Occasionally, a request may fail due to temporary issues such as timeouts. Use the `-retries` flag to specify how many times a failed page should be retried before giving up:
+```sh
+anyflip-downloader -retires <number of attempts> <url to book>
+```
+
+#### Retry delay
+To avoid overwhelming the server or triggering rate limits, you can introduce a delay between retry attempts. The `-waitretry` flag accepts any valid Go duration format (e.g., 500ms, 2s, 1m).
+```sh
+anyflip-downloader -waitretry <duration> <url to book>
+```

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func (fb *flipbook) downloadPage(page int, folder string, options downloadOption
 	var resp *http.Response
 	var err error
 
-	for attempt := 1; attempt <= options.retries; attempt++ {
+	for attempt := 0; attempt <= options.retries; attempt++ {
 		resp, err = http.Get(downloadURL)
 		if err == nil {
 			break

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/pdfcpu/pdfcpu/pkg/api"
@@ -25,6 +27,9 @@ var title string
 var tempDownloadFolder string
 var insecure bool
 var keepDownloadFolder bool
+var donwloadThreads int
+var downloadRetries int
+var downloadRetryDelay time.Duration
 
 type flipbook struct {
 	URL       *url.URL
@@ -33,12 +38,21 @@ type flipbook struct {
 	pageURLs  []string
 }
 
+type donwloadOptions struct {
+	threads    int
+	retries    int
+	retryDelay time.Duration
+}
+
 func init() {
 	flag.Usage = printUsage
 	flag.StringVar(&tempDownloadFolder, "temp-download-folder", "", "Specifies the name of the temporary download folder")
 	flag.StringVar(&title, "title", "", "Specifies the name of the generated PDF document (uses book title if not specified)")
 	flag.BoolVar(&insecure, "insecure", false, "Skip certificate validation")
 	flag.BoolVar(&keepDownloadFolder, "keep-download-folder", false, "Keep the temporary download folder instead of deleting it after completion")
+	flag.IntVar(&donwloadThreads, "threads", 1, "Number of parallel download processes")
+	flag.IntVar(&downloadRetries, "retries", 1, "Number of download retries")
+	flag.DurationVar(&downloadRetryDelay, "waitretry", time.Second, "Wait time between download retries")
 }
 
 func main() {
@@ -64,7 +78,7 @@ func main() {
 	}
 	outputFile := title + ".pdf"
 
-	err = flipbook.downloadImages(tempDownloadFolder)
+	err = flipbook.downloadImages(tempDownloadFolder, donwloadOptions{threads: donwloadThreads, retries: downloadRetries, retryDelay: downloadRetryDelay})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -168,7 +182,7 @@ func createPDF(outputFile string, imageDir string) error {
 	return err
 }
 
-func (fb *flipbook) downloadImages(downloadFolder string) error {
+func (fb *flipbook) downloadImages(downloadFolder string, options donwloadOptions) error {
 	err := os.Mkdir(downloadFolder, os.ModePerm)
 	if err != nil {
 		return err
@@ -181,34 +195,88 @@ func (fb *flipbook) downloadImages(downloadFolder string) error {
 		progressbar.OptionSetDescription("Downloading"),
 	)
 
-	for page := 0; page < fb.pageCount; page++ {
-		downloadURL := fb.pageURLs[page]
-		response, err := http.Get(downloadURL)
-		if err != nil {
-			return err
-		}
+	downloadPages := make(chan int)
+	downloadErrors := make(chan error)
 
-		if response.StatusCode != http.StatusOK {
-			println("During download from ", downloadURL)
-			return errors.New("Received non-200 response: " + response.Status)
-		}
+	var wg sync.WaitGroup
+	wg.Add(options.threads)
 
-		extension := path.Ext(downloadURL)
-		filename := fmt.Sprintf("%04d%v", page, extension)
-		file, err := os.Create(path.Join(downloadFolder, filename))
-		if err != nil {
-			return err
+	// Generate pages to download
+	go func() {
+		for page := 0; page < fb.pageCount; page++ {
+			downloadPages <- page
 		}
-		defer file.Close()
+		close(downloadPages)
+	}()
 
-		_, err = io.Copy(file, response.Body)
-		if err != nil {
-			return err
-		}
+	for thread := 0; thread < options.threads; thread++ {
+		go func() {
+			defer wg.Done()
 
-		bar.Add(1)
+			for page := range downloadPages {
+				func() {
+					downloadURL := fb.pageURLs[page]
+
+					var response *http.Response
+					var err error
+
+					for attempt := 1; attempt <= options.retries; attempt++ {
+						response, err = http.Get(downloadURL)
+						if err == nil {
+							break
+						}
+
+						if attempt < options.retries {
+							time.Sleep(options.retryDelay)
+						} else {
+							downloadErrors <- fmt.Errorf("download failed after %d attempts: %w", options.retries, err)
+							return
+						}
+					}
+					defer response.Body.Close()
+
+					if response.StatusCode != http.StatusOK {
+						downloadErrors <- fmt.Errorf("during download from %s received non-200 response: %s", downloadURL, response.Status)
+						return
+					}
+
+					extension := path.Ext(downloadURL)
+					filename := fmt.Sprintf("%04d%v", page, extension)
+					file, err := os.Create(path.Join(downloadFolder, filename))
+					if err != nil {
+						downloadErrors <- err
+						return
+					}
+					defer file.Close()
+
+					_, err = io.Copy(file, response.Body)
+					if err != nil {
+						downloadErrors <- err
+						return
+					}
+
+					bar.Add(1)
+				}()
+			}
+		}()
 	}
+
+	// Wait for all downloads to finish
+	go func() {
+		wg.Wait()
+		close(downloadErrors)
+	}()
+
+	var errors []error
+	for err := range downloadErrors {
+		fmt.Printf("Error occured: %e\n", err)
+		errors = append(errors, err)
+	}
+
 	fmt.Println()
+	if len(errors) > 0 {
+		return errors[0]
+	}
 	return nil
 }
 


### PR DESCRIPTION
While using this tool, I found it is extremely slow to download files for the first time. Therefore, some improvements have been made.

This PR introduces the following:
- Parallel image downloads with `--threads` option
- Specify the retry number with the `--retries` option
- Specify wait time for the retry with `--waitretry` option

The default value for the `--threads` is 1, preserving the previous behavior. From the testing, an increasing number of threads up to 5 can decrease download time twice.