### PR TITLE
Match Dockerfile Golang version to go.mod version 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
I noticed when running the docker build that it currently fails due to a version differential between the dockerfile and the go.mod file.