### PR TITLE
fix: print usage instead of panicking when no URL provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,12 @@ func main() {
 }
 
 func run() {
+	if flag.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "error: no URL provided")
+		printUsage()
+		os.Exit(1)
+	}
+
 	anyflipURL, err := url.Parse(flag.Args()[0])
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Fixes #97

Running `anyflip-downloader` without arguments panics because `flag.Args()[0]` indexes into an empty slice. Added a `flag.NArg()` check that prints a helpful error + usage text and exits cleanly.

— saschabuehrle